### PR TITLE
FVDRKIT-50 Use UTC for modification time when unzipping

### DIFF
--- a/ZipArchive.m
+++ b/ZipArchive.m
@@ -397,6 +397,7 @@
                     components.year = fileInfo.tmu_date.tm_year;
                     
                     NSCalendar *gregorianCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+                    [gregorianCalendar setTimeZone:[NSTimeZone timeZoneWithAbbreviation:@"UTC"]];
                     NSDate* orgDate = [[gregorianCalendar dateFromComponents:components] retain];
                     [components release];
                     [gregorianCalendar release];


### PR DESCRIPTION
//cc @rk-yen @aldryd 

I noticed that the timestamps on the database files pulled from the drive weren't being handled correctly.
